### PR TITLE
Added `npm config set save true` tip

### DIFF
--- a/tips.txt
+++ b/tips.txt
@@ -14,3 +14,4 @@ You can use `http://npm.im/<packagename>` to link to packages.
 You can run any script using `npm run [script name]` with the [scripts property](https://docs.npmjs.com/misc/scripts)
 `npm start` is a shortcut for `npm run start`
 Use #<branch> to specify git branch to install i.e. `git://github.com/<user>/<project>.git#<branch>`
+Prevent forgetting to use `--save` with `npm config set save true`


### PR DESCRIPTION
One tip I have found useful is to always save packages by default with `save=true` in `.npmrc`. In this PR:
- Added tip about saving packages by default (e.g. without `--save` or `--save-dev`)
