### PR TITLE
npm config set prefix ~/npm -g

### DIFF
--- a/tips.txt
+++ b/tips.txt
@@ -14,3 +14,4 @@ You can use `http://npm.im/<packagename>` to link to packages.
 You can run any script using `npm run [script name]` with the [scripts property](https://docs.npmjs.com/misc/scripts)
 `npm start` is a shortcut for `npm run start`
 Use #<branch> to specify git branch to install i.e. `git://github.com/<user>/<project>.git#<branch>`
+Set npm's global directory to avoid `sudo`: `npm config set prefix ~/npm —g`


### PR DESCRIPTION
From https://medium.com/@adambretz/su-dont-npm-install-295376e2e5f8

It's great not having to use sudo to install anything. :)

Let me know if it's reasonable or let me know what a better form might be, and I can have a go at refining it.
