### PR TITLE
Add ./node_modules/.bin to $PATH

### DIFF
--- a/tips.txt
+++ b/tips.txt
@@ -21,3 +21,4 @@ You can install GitHub repos with `npm i org-name/repo-name`
 `npm docs <packagename>` opens package docs in a web browser
 Regularly update npm with `npm i -g npm`
 Avoid `sudo` by [setting a global root directory](https://docs.npmjs.com/getting-started/fixing-npm-permissions)
+Add `./node_modules/.bin` to your `$PATH` to run locally installed binaries by name


### PR DESCRIPTION
I really enjoy being able to run locally installed binaries as if they were installed globally and always have something like this in my shell configs:

```
PATH=$PATH:./node_modules/.bin
```

One important detail is to make sure `./node_modules/.bin` comes after `/bin`, `/usr/bin`, etc to prevent malicious packages from overriding `ls` or other system tools. Not sure how to cover it though.
